### PR TITLE
Fixed chrome support : backface-visibility bug

### DIFF
--- a/src/Flip.vue
+++ b/src/Flip.vue
@@ -116,6 +116,7 @@
   }
 
   .front, .back {
+    transform-style: preserve-3d; /* this fixed chrome issue*/
     -webkit-backface-visibility: hidden;
        -moz-backface-visibility: hidden;
             backface-visibility: hidden;


### PR DESCRIPTION
Added preserve-3d to .front and .back to fix a loading issue specific to certain versions of chrome and the backface-visibility setting.  

On my chrome version (Version 78.0.3904.70 (Official Build) (64-bit) (macOS Mojave 10.14.6)), the card was temporarily disappearing/studdering during the flip animation making it look broken, several other people online had similar issues.  

I don't totally understand why the issue is chrome specific or why the preserve-3d in the .front and .back classes fixes it but it worked for me along with another person online.